### PR TITLE
Store를 slice단위로 구독하기

### DIFF
--- a/src/components/domain/auth/SignUpForm.tsx
+++ b/src/components/domain/auth/SignUpForm.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, ChangeEventHandler, useState } from "react";
 import { UserInputClass } from "../../../types/classImplementations";
-import { useAuthSlice, useThemeSlice, useBoundStore } from "../../../store/index";
+import { useAuthSlice, useThemeSlice } from "../../../store/index";
 import { useNavigate } from "react-router-dom";
 import TextField from "@mui/material/TextField";
 import { MenuItem } from "@mui/material";

--- a/src/components/domain/auth/SignUpForm.tsx
+++ b/src/components/domain/auth/SignUpForm.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, ChangeEventHandler, useState } from "react";
 import { UserInputClass } from "../../../types/classImplementations";
-import { useBoundStore } from "../../../store/index";
+import { useAuthSlice, useThemeSlice, useBoundStore } from "../../../store/index";
 import { useNavigate } from "react-router-dom";
 import TextField from "@mui/material/TextField";
 import { MenuItem } from "@mui/material";
@@ -10,13 +10,14 @@ import { CommonButtonLarge, MuiButton } from "../../UI/CommonButton";
 import { Toast } from "../../UI/Toast";
 
 const SignUpForm = () => {
-  const AuthSlice: AuthSlice = useBoundStore((state) => state);
-  const isToastOpen = useBoundStore((state) => state.isToastOpen);
-  const setIsToastOpen = useBoundStore((state) => state.setIsToastOpen);
-  const bgColor = useBoundStore((state) => state.bgColor);
-  const setBgColor = useBoundStore((state) => state.setBgColor);
-  const toastMessage = useBoundStore((state) => state.alertText);
-  const setToastMessage = useBoundStore((state) => state.setAlertText);
+  const AuthSlice: AuthSlice = useAuthSlice();
+  const ThemeSlice: ThemeSlice = useThemeSlice();
+  const isToastOpen = ThemeSlice.isToastOpen
+  const setIsToastOpen= ThemeSlice.setIsToastOpen
+  const bgColor = ThemeSlice.bgColor
+  const setBgColor = ThemeSlice.setBgColor
+  const toastMessage = ThemeSlice.alertText
+  const setToastMessage = ThemeSlice.setAlertText
   const navigate = useNavigate();
   const [userInputs, setUserInputs] = useState<UserInputClass>(
     new UserInputClass()

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,3 @@
-// import { updateTokenStore } from './authSlice';
 // // zustand store 생성
 import { create } from "zustand";
 import { createJSONStorage, devtools, persist } from "zustand/middleware";
@@ -12,7 +11,7 @@ import { createImageSlice } from "./imageSlice";
 import { createCustomAxiosSlice } from "./customAxiosSlice";
 
 export const useBoundStore = create<
-  AuthSlice &
+    AuthSlice &
     MyPageSlice &
     PurchaseSlice &
     ProductSlice &
@@ -48,3 +47,42 @@ export const useBoundStore = create<
     )
   )
 );
+
+
+export const useAuth = () => useBoundStore((state)=>{
+  return  {
+  userToken: state.userToken,
+  userBasicInfo : state.userBasicInfo,
+  isLoggedIn: state.isLoggedIn,
+  verifyEmail: state.verifyEmail,
+  signUp: state.signUp,
+  login: state.login,
+  updateUserBasicInfo: state.updateUserBasicInfo,
+  logout: state.logout,
+}})
+
+
+export const useMyPage = () => useBoundStore((state)=>{
+  return {
+    getMyInfo : state.getMyInfo,
+    setMyInfo : state.setMyInfo,
+    updateMyInfo : state.updateMyInfo,
+    getMyProducts : state.getMyProducts,
+}})
+
+
+export const useTheme = () => useBoundStore((state)=>{
+  return {
+  isDark: state.isDark,
+  setIsDark: state.setIsDark,
+  isToastOpen: state.isToastOpen,
+  alertText: state.alertText,
+  bgColor: state.bgColor,
+  navSelectedValue: state.navSelectedValue,
+  setNavSelected: state.setNavSelected,
+  setIsToastOpen: state.setIsToastOpen,
+  setAlertText: state.setAlertText,
+  setBgColor: state.setBgColor,
+  }
+})
+

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -59,16 +59,17 @@ export const useAuth = () => useBoundStore((state)=>{
   login: state.login,
   updateUserBasicInfo: state.updateUserBasicInfo,
   logout: state.logout,
-}})
+} satisfies AuthSlice})
 
 
 export const useMyPage = () => useBoundStore((state)=>{
   return {
+    myInfo: state.myInfo,
     getMyInfo : state.getMyInfo,
     setMyInfo : state.setMyInfo,
     updateMyInfo : state.updateMyInfo,
     getMyProducts : state.getMyProducts,
-}})
+} satisfies MyPageSlice})
 
 
 export const useTheme = () => useBoundStore((state)=>{
@@ -83,6 +84,5 @@ export const useTheme = () => useBoundStore((state)=>{
   setIsToastOpen: state.setIsToastOpen,
   setAlertText: state.setAlertText,
   setBgColor: state.setBgColor,
-  }
-})
+  } satisfies ThemeSlice})
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -49,7 +49,7 @@ export const useBoundStore = create<
 );
 
 
-export const useAuth = () => useBoundStore((state)=>{
+export const useAuthSlice = () => useBoundStore((state)=>{
   return  {
   userToken: state.userToken,
   userBasicInfo : state.userBasicInfo,
@@ -62,7 +62,7 @@ export const useAuth = () => useBoundStore((state)=>{
 } satisfies AuthSlice})
 
 
-export const useMyPage = () => useBoundStore((state)=>{
+export const useMyPageSlice = () => useBoundStore((state)=>{
   return {
     myInfo: state.myInfo,
     getMyInfo : state.getMyInfo,
@@ -72,7 +72,7 @@ export const useMyPage = () => useBoundStore((state)=>{
 } satisfies MyPageSlice})
 
 
-export const useTheme = () => useBoundStore((state)=>{
+export const useThemeSlice = () => useBoundStore((state)=>{
   return {
   isDark: state.isDark,
   setIsDark: state.setIsDark,
@@ -85,4 +85,38 @@ export const useTheme = () => useBoundStore((state)=>{
   setAlertText: state.setAlertText,
   setBgColor: state.setBgColor,
   } satisfies ThemeSlice})
+
+
+export const usePurchaseSlice = () => useBoundStore((state)=>{
+  return {
+    productDetailData: state.productDetailData,
+    setProductDetailData: state.setProductDetailData,
+  } satisfies PurchaseSlice})
+
+
+export const useSearchSlice = () => useBoundStore((state)=>{
+  return {
+    searchItemsInThisBound: state.searchItemsInThisBound, 
+    searchItemsInThisBoundAndPeriod : state.searchItemsInThisBoundAndPeriod,
+  } satisfies SearchSlice })
+
+
+export const useProductSlice = () => useBoundStore((state) => {
+  return {
+    productItem : state.productItem,
+    productList : state.productList,
+  } satisfies ProductSlice })
+
+
+export const useImageSlice = () => useBoundStore((state)=>{
+  return {
+  uploadImage : state.uploadImage
+} satisfies ImageSlice})
+
+
+export const useCustomAxiosSlice = () => useBoundStore((state)=>{
+  return {
+  useCustomAxios : state.useCustomAxios
+} satisfies customAxiosSlice})
+// customAxiosSlice
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,7 @@
 // import { updateTokenStore } from './authSlice';
 // // zustand store 생성
 import { create } from "zustand";
-import { devtools, persist } from "zustand/middleware";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
 import { createAuthSlice } from "./authSlice";
 import { createMyPageSlice } from "./MyPageSlice";
 import { createProductSlice } from "./ProductSlice";
@@ -43,6 +43,7 @@ export const useBoundStore = create<
           isDark: state.isDark,
           navSelectedValue: state.navSelectedValue,
         }),
+        storage: createJSONStorage(() => sessionStorage),
       }
     )
   )


### PR DESCRIPTION
기존 코드에서는 BoundStore 형식으로만 store 구독이 가능했었는데요, 이제는 slice 단위로 구독하는 것이 가능해졌습니다. slice export를 위해 index.ts에서 52~120 줄이 추가가 되었는데요, satisfies 연산자를 통해서 타입 검사를 한번 더 수행하면서 코드의 안정성을 높였습니다. slice를 구독하여 사용하는 예시를 SignUpForm.tsx에서 볼 수 있습니다.